### PR TITLE
Remove mysql version pinning to mysql-server-5.6

### DIFF
--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: mysql-server - installation
   apt:
-    pkg: mysql-server-5.6
+    pkg: mysql-server
     state: present
 
 - name: python-mysqldb - installation


### PR DESCRIPTION
Ubuntu 18.04 LTS has 5.7 which is functionally the same, similarly other distributions don't necessarily have 5.6. Removing the version pin should make it work in a higher percentage of installs...